### PR TITLE
@waline/client报错，Image组件添加占位图，skeleton冲突

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -82,7 +82,7 @@
         "remark-gfm": "^3.0.1",
         "tailwindcss": "^3.3.5",
         "ts-node": "^10.9.1",
-        "typescript": "^4.9.5",
+        "typescript": "4.9.5",
       },
     },
   },

--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "@tanstack/react-table": "^8.10.7",
         "@types/katex": "^0.16.7",
         "@types/react-katex": "^3.0.4",
-        "@waline/client": "^3.1.3",
+        "@waline/client": "~3.3.0",
         "axios": "^0.24.0",
         "caniuse-lite": "^1.0.30001706",
         "cloudinary-build-url": "^0.2.4",
@@ -82,7 +82,7 @@
         "remark-gfm": "^3.0.1",
         "tailwindcss": "^3.3.5",
         "ts-node": "^10.9.1",
-        "typescript": "4.9.5",
+        "typescript": "^4.9.5",
       },
     },
   },
@@ -497,13 +497,13 @@
 
     "@tanstack/eslint-plugin-query": ["@tanstack/eslint-plugin-query@5.0.0", "https://registry.npmmirror.com/@tanstack/eslint-plugin-query/-/eslint-plugin-query-5.0.0.tgz", { "dependencies": { "@typescript-eslint/utils": "^5.54.0" }, "peerDependencies": { "eslint": "^8.0.0" } }, "sha512-jHGeUY9cdM1pp/C4y24vynaFjWZDBhx9xPap5v4ysXiQRZAe2W8bdMq6PcnnKJJG8XsGLrvgK6G+hkcGO3yHqw=="],
 
-    "@tanstack/query-core": ["@tanstack/query-core@5.72.1", "https://registry.npmmirror.com/@tanstack/query-core/-/query-core-5.72.1.tgz", {}, "sha512-nOu0EEkZuJ0BZnYgeaEfo44+psq1jBO7/zp3KudixD4dvgOVerrhAhDEKsWx2N7MxB59mjO4r0ddP/VqWGPK+Q=="],
+    "@tanstack/query-core": ["@tanstack/query-core@5.72.2", "https://registry.npmmirror.com/@tanstack/query-core/-/query-core-5.72.2.tgz", {}, "sha512-fxl9/0yk3mD/FwTmVEf1/H6N5B975H0luT+icKyX566w6uJG0x6o+Yl+I38wJRCaogiMkstByt+seXfDbWDAcA=="],
 
-    "@tanstack/query-devtools": ["@tanstack/query-devtools@5.72.0", "https://registry.npmmirror.com/@tanstack/query-devtools/-/query-devtools-5.72.0.tgz", {}, "sha512-/SJr77+epgxmwMB5Wjlg1TiN6bJObAJKi/mIHWQcon0VJxH3NNOtGCpQRbWih8xOq9oQ5kuIYLftYfD0j2ujew=="],
+    "@tanstack/query-devtools": ["@tanstack/query-devtools@5.72.2", "https://registry.npmmirror.com/@tanstack/query-devtools/-/query-devtools-5.72.2.tgz", {}, "sha512-mMKnGb+iOhVBcj6jaerCFRpg8pACStdG8hmUBHPtToeZzs4ctjBUL1FajqpVn2WaMxnq8Wya+P3Q5tPFNM9jQw=="],
 
-    "@tanstack/react-query": ["@tanstack/react-query@5.72.1", "https://registry.npmmirror.com/@tanstack/react-query/-/react-query-5.72.1.tgz", { "dependencies": { "@tanstack/query-core": "5.72.1" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-4UEMyRx54xj144D2nDvDIMiXSG5BrqyCJrmyNoGbymNS+VWODcBDFrmRk9p2fe12UGZ4JtKPTNuW2Jg0aisUgQ=="],
+    "@tanstack/react-query": ["@tanstack/react-query@5.72.2", "https://registry.npmmirror.com/@tanstack/react-query/-/react-query-5.72.2.tgz", { "dependencies": { "@tanstack/query-core": "5.72.2" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-SVNHzyBUYiis+XiCl+8yiPZmMYei2AKYY94wM/zpvB5l1jxqOo82FQTziSJ4pBi96jtYqvYrTMxWynmbQh3XKw=="],
 
-    "@tanstack/react-query-devtools": ["@tanstack/react-query-devtools@5.72.0", "https://registry.npmmirror.com/@tanstack/react-query-devtools/-/react-query-devtools-5.72.0.tgz", { "dependencies": { "@tanstack/query-devtools": "5.72.0" }, "peerDependencies": { "@tanstack/react-query": "^5.72.0", "react": "^18 || ^19" } }, "sha512-xhZbLnZLZvHw+c+R6jWWrr14IO9jjrDKkpIJVD/Tk3KOzQK+Olk0UiWbrZTuHKvDqFMICNBp94SbRyuR0H2kUQ=="],
+    "@tanstack/react-query-devtools": ["@tanstack/react-query-devtools@5.72.2", "https://registry.npmmirror.com/@tanstack/react-query-devtools/-/react-query-devtools-5.72.2.tgz", { "dependencies": { "@tanstack/query-devtools": "5.72.2" }, "peerDependencies": { "@tanstack/react-query": "^5.72.2", "react": "^18 || ^19" } }, "sha512-n53qr9JdHCJTCUba6OvMhwiV2CcsckngOswKEE7nM5pQBa/fW9c43qw8omw1RPT2s+aC7MuwS8fHsWT8g+j6IQ=="],
 
     "@tanstack/react-table": ["@tanstack/react-table@8.21.2", "https://registry.npmmirror.com/@tanstack/react-table/-/react-table-8.21.2.tgz", { "dependencies": { "@tanstack/table-core": "8.21.2" }, "peerDependencies": { "react": ">=16.8", "react-dom": ">=16.8" } }, "sha512-11tNlEDTdIhMJba2RBH+ecJ9l1zgS2kjmexDPAraulc8jeNA4xocSNeyzextT0XJyASil4XsCYlJmf5jEWAtYg=="],
 
@@ -577,7 +577,7 @@
 
     "@types/unist": ["@types/unist@2.0.11", "https://registry.npmmirror.com/@types/unist/-/unist-2.0.11.tgz", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
-    "@types/web-bluetooth": ["@types/web-bluetooth@0.0.21", "https://registry.npmmirror.com/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz", {}, "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA=="],
+    "@types/web-bluetooth": ["@types/web-bluetooth@0.0.20", "https://registry.npmmirror.com/@types/web-bluetooth/-/web-bluetooth-0.0.20.tgz", {}, "sha512-g9gZnnXVq7gM7v3tJCWV/qw7w+KeOlSHAhgF9RytFyifW6AF61hdT2ucrYhPq9hLs5JIryeupHV3qGk95dH9ow=="],
 
     "@types/yauzl": ["@types/yauzl@2.10.3", "https://registry.npmmirror.com/@types/yauzl/-/yauzl-2.10.3.tgz", { "dependencies": { "@types/node": "*" } }, "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q=="],
 
@@ -615,15 +615,15 @@
 
     "@vue/shared": ["@vue/shared@3.5.13", "https://registry.npmmirror.com/@vue/shared/-/shared-3.5.13.tgz", {}, "sha512-/hnE/qP5ZoGpol0a5mDi45bOd7t3tjYJBjsgCsivow7D48cJeV5l05RD82lPqi7gRiphZM37rnhW1l6ZoCNNnQ=="],
 
-    "@vueuse/core": ["@vueuse/core@13.1.0", "https://registry.npmmirror.com/@vueuse/core/-/core-13.1.0.tgz", { "dependencies": { "@types/web-bluetooth": "^0.0.21", "@vueuse/metadata": "13.1.0", "@vueuse/shared": "13.1.0" }, "peerDependencies": { "vue": "^3.5.0" } }, "sha512-PAauvdRXZvTWXtGLg8cPUFjiZEddTqmogdwYpnn60t08AA5a8Q4hZokBnpTOnVNqySlFlTcRYIC8OqreV4hv3Q=="],
+    "@vueuse/core": ["@vueuse/core@11.3.0", "https://registry.npmmirror.com/@vueuse/core/-/core-11.3.0.tgz", { "dependencies": { "@types/web-bluetooth": "^0.0.20", "@vueuse/metadata": "11.3.0", "@vueuse/shared": "11.3.0", "vue-demi": ">=0.14.10" } }, "sha512-7OC4Rl1f9G8IT6rUfi9JrKiXy4bfmHhZ5x2Ceojy0jnd3mHNEvV4JaRygH362ror6/NZ+Nl+n13LPzGiPN8cKA=="],
 
-    "@vueuse/metadata": ["@vueuse/metadata@13.1.0", "https://registry.npmmirror.com/@vueuse/metadata/-/metadata-13.1.0.tgz", {}, "sha512-+TDd7/a78jale5YbHX9KHW3cEDav1lz1JptwDvep2zSG8XjCsVE+9mHIzjTOaPbHUAk5XiE4jXLz51/tS+aKQw=="],
+    "@vueuse/metadata": ["@vueuse/metadata@11.3.0", "https://registry.npmmirror.com/@vueuse/metadata/-/metadata-11.3.0.tgz", {}, "sha512-pwDnDspTqtTo2HwfLw4Rp6yywuuBdYnPYDq+mO38ZYKGebCUQC/nVj/PXSiK9HX5otxLz8Fn7ECPbjiRz2CC3g=="],
 
-    "@vueuse/shared": ["@vueuse/shared@13.1.0", "https://registry.npmmirror.com/@vueuse/shared/-/shared-13.1.0.tgz", { "peerDependencies": { "vue": "^3.5.0" } }, "sha512-IVS/qRRjhPTZ6C2/AM3jieqXACGwFZwWTdw5sNTSKk2m/ZpkuuN+ri+WCVUP8TqaKwJYt/KuMwmXspMAw8E6ew=="],
+    "@vueuse/shared": ["@vueuse/shared@11.3.0", "https://registry.npmmirror.com/@vueuse/shared/-/shared-11.3.0.tgz", { "dependencies": { "vue-demi": ">=0.14.10" } }, "sha512-P8gSSWQeucH5821ek2mn/ciCk+MS/zoRKqdQIM3bHq6p7GXDAJLmnRRKmF5F65sAVJIfzQlwR3aDzwCn10s8hA=="],
 
-    "@waline/api": ["@waline/api@1.0.0", "https://registry.npmmirror.com/@waline/api/-/api-1.0.0.tgz", {}, "sha512-o0lWjt+/oZH1/4q3DJxTf5kdkgNbSmoLRXIiGznW225A6hq9/9IkOO1DiAijIsxGYJS6psFC+58+IzkD1EerBA=="],
+    "@waline/api": ["@waline/api@1.0.0-alpha.8", "https://registry.npmmirror.com/@waline/api/-/api-1.0.0-alpha.8.tgz", {}, "sha512-S6pgUUfv+gcXU3hiW3PNUwiUvPy7bXmmLB/bwdU3hN5YVT5Q7CxyVSLA3oJkrNO5lcisKK1GBPv0H2W1uB0eGA=="],
 
-    "@waline/client": ["@waline/client@3.5.6", "https://registry.npmmirror.com/@waline/client/-/client-3.5.6.tgz", { "dependencies": { "@vueuse/core": "^13.0.0", "@waline/api": "1.0.0", "autosize": "^6.0.1", "marked": "^15.0.7", "marked-highlight": "^2.2.1", "recaptcha-v3": "^1.11.3", "vue": "^3.5.13" } }, "sha512-K+mfUpuLilzFUN3G84ytB02v5EkaaU0eOyN6BILcSozjUpSsggbgcy73WBiuUVg8u7pRsIvx192/PclJYvaWCg=="],
+    "@waline/client": ["@waline/client@3.3.2", "https://registry.npmmirror.com/@waline/client/-/client-3.3.2.tgz", { "dependencies": { "@vueuse/core": "^11.0.3", "@waline/api": "1.0.0-alpha.8", "autosize": "^6.0.1", "marked": "^14.1.1", "marked-highlight": "^2.1.4", "recaptcha-v3": "^1.11.3", "vue": "^3.5.3" } }, "sha512-CK8ef5QafKt29AAz3n+bXNwzXdT/yh+pMRLxxTNH4RAMl0Wl3utqh3uA/gDpNRLWS4sOkFMASUC0ckbpeOAJNg=="],
 
     "JSONStream": ["JSONStream@1.3.5", "https://registry.npmmirror.com/JSONStream/-/JSONStream-1.3.5.tgz", { "dependencies": { "jsonparse": "^1.2.0", "through": ">=2.2.7 <3" }, "bin": { "JSONStream": "./bin.js" } }, "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ=="],
 
@@ -773,7 +773,7 @@
 
     "camelcase-keys": ["camelcase-keys@6.2.2", "https://registry.npmmirror.com/camelcase-keys/-/camelcase-keys-6.2.2.tgz", { "dependencies": { "camelcase": "^5.3.1", "map-obj": "^4.0.0", "quick-lru": "^4.0.1" } }, "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg=="],
 
-    "caniuse-lite": ["caniuse-lite@1.0.30001712", "https://registry.npmmirror.com/caniuse-lite/-/caniuse-lite-1.0.30001712.tgz", {}, "sha512-MBqPpGYYdQ7/hfKiet9SCI+nmN5/hp4ZzveOJubl5DTAMa5oggjAuoi0Z4onBpKPFI2ePGnQuQIzF3VxDjDJig=="],
+    "caniuse-lite": ["caniuse-lite@1.0.30001713", "https://registry.npmmirror.com/caniuse-lite/-/caniuse-lite-1.0.30001713.tgz", {}, "sha512-wCIWIg+A4Xr7NfhTuHdX+/FKh3+Op3LBbSp2N5Pfx6T/LhdQy3GTyoTg48BReaW/MyMNZAkTadsBtai3ldWK0Q=="],
 
     "caseless": ["caseless@0.12.0", "https://registry.npmmirror.com/caseless/-/caseless-0.12.0.tgz", {}, "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="],
 
@@ -949,7 +949,7 @@
 
     "ee-first": ["ee-first@1.1.1", "https://registry.npmmirror.com/ee-first/-/ee-first-1.1.1.tgz", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
-    "electron-to-chromium": ["electron-to-chromium@1.5.134", "https://registry.npmmirror.com/electron-to-chromium/-/electron-to-chromium-1.5.134.tgz", {}, "sha512-zSwzrLg3jNP3bwsLqWHmS5z2nIOQ5ngMnfMZOWWtXnqqQkPVyOipxK98w+1beLw1TB+EImPNcG8wVP/cLVs2Og=="],
+    "electron-to-chromium": ["electron-to-chromium@1.5.136", "https://registry.npmmirror.com/electron-to-chromium/-/electron-to-chromium-1.5.136.tgz", {}, "sha512-kL4+wUTD7RSA5FHx5YwWtjDnEEkIIikFgWHR4P6fqjw1PPLlqYkxeOb++wAauAssat0YClCy8Y3C5SxgSkjibQ=="],
 
     "emoji-regex": ["emoji-regex@9.2.2", "https://registry.npmmirror.com/emoji-regex/-/emoji-regex-9.2.2.tgz", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
@@ -1383,7 +1383,7 @@
 
     "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "https://registry.npmmirror.com/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz", { "dependencies": { "array-includes": "^3.1.6", "array.prototype.flat": "^1.3.1", "object.assign": "^4.1.4", "object.values": "^1.1.6" } }, "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ=="],
 
-    "katex": ["katex@0.16.21", "https://registry.npmmirror.com/katex/-/katex-0.16.21.tgz", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-XvqR7FgOHtWupfMiigNzmh+MgUVmDGU2kXZm899ZkPfcuoPuFxyHmXsgATDpFZDAXCI8tvinaVcDo8PIIJSo4A=="],
+    "katex": ["katex@0.16.22", "https://registry.npmmirror.com/katex/-/katex-0.16.22.tgz", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-XCHRdUw4lf3SKBaJe4EvgqIuWwkPSo9XoeO8GjQW94Bp7TWv9hNhzZjZ+OH9yf1UmLygb7DIT5GSFQiyt16zYg=="],
 
     "keyv": ["keyv@4.5.4", "https://registry.npmmirror.com/keyv/-/keyv-4.5.4.tgz", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
@@ -1465,7 +1465,7 @@
 
     "markdown-table": ["markdown-table@3.0.4", "https://registry.npmmirror.com/markdown-table/-/markdown-table-3.0.4.tgz", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
 
-    "marked": ["marked@15.0.8", "https://registry.npmmirror.com/marked/-/marked-15.0.8.tgz", { "bin": { "marked": "bin/marked.js" } }, "sha512-rli4l2LyZqpQuRve5C0rkn6pj3hT8EWPC+zkAxFTAJLxRbENfTAhEQq9itrmf1Y81QtAX5D/MYlGlIomNgj9lA=="],
+    "marked": ["marked@14.1.4", "https://registry.npmmirror.com/marked/-/marked-14.1.4.tgz", { "bin": { "marked": "bin/marked.js" } }, "sha512-vkVZ8ONmUdPnjCKc5uTRvmkRbx4EAi2OkTOXmfTDhZz3OFqMNBM1oTTWwTr4HY4uAEojhzPf+Fy8F1DWa3Sndg=="],
 
     "marked-highlight": ["marked-highlight@2.2.1", "https://registry.npmmirror.com/marked-highlight/-/marked-highlight-2.2.1.tgz", { "peerDependencies": { "marked": ">=4 <16" } }, "sha512-SiCIeEiQbs9TxGwle9/OwbOejHCZsohQRaNTY2u8euEXYt2rYUFoiImUirThU3Gd/o6Q1gHGtH9qloHlbJpNIA=="],
 
@@ -2191,6 +2191,8 @@
 
     "vue": ["vue@3.5.13", "https://registry.npmmirror.com/vue/-/vue-3.5.13.tgz", { "dependencies": { "@vue/compiler-dom": "3.5.13", "@vue/compiler-sfc": "3.5.13", "@vue/runtime-dom": "3.5.13", "@vue/server-renderer": "3.5.13", "@vue/shared": "3.5.13" }, "peerDependencies": { "typescript": "*" }, "optionalPeers": ["typescript"] }, "sha512-wmeiSMxkZCSc+PM2w2VRsOYAZC8GdipNFRTsLSfodVqI9mbejKeXEGr8SckuLnrQPGe3oJN5c3K0vpoU9q/wCQ=="],
 
+    "vue-demi": ["vue-demi@0.14.10", "https://registry.npmmirror.com/vue-demi/-/vue-demi-0.14.10.tgz", { "peerDependencies": { "@vue/composition-api": "^1.0.0-rc.1", "vue": "^3.0.0-0 || ^2.6.0" }, "optionalPeers": ["@vue/composition-api"], "bin": { "vue-demi-fix": "bin/vue-demi-fix.js", "vue-demi-switch": "bin/vue-demi-switch.js" } }, "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg=="],
+
     "warning": ["warning@4.0.3", "https://registry.npmmirror.com/warning/-/warning-4.0.3.tgz", { "dependencies": { "loose-envify": "^1.0.0" } }, "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w=="],
 
     "web-namespaces": ["web-namespaces@2.0.1", "https://registry.npmmirror.com/web-namespaces/-/web-namespaces-2.0.1.tgz", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
@@ -2450,8 +2452,6 @@
     "regjsparser/jsesc": ["jsesc@3.0.2", "https://registry.npmmirror.com/jsesc/-/jsesc-3.0.2.tgz", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g=="],
 
     "remark-mdx-frontmatter/js-yaml": ["js-yaml@4.1.0", "https://registry.npmmirror.com/js-yaml/-/js-yaml-4.1.0.tgz", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
-
-    "rimraf/glob": ["glob@7.2.3", "https://registry.npmmirror.com/glob/-/glob-7.2.3.tgz", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
 
     "rxjs/tslib": ["tslib@2.8.1", "https://registry.npmmirror.com/tslib/-/tslib-2.8.1.tgz", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@tanstack/react-table": "^8.10.7",
     "@types/katex": "^0.16.7",
     "@types/react-katex": "^3.0.4",
-    "@waline/client": "^3.1.3",
+    "@waline/client": "~3.3.0",
     "axios": "^0.24.0",
     "caniuse-lite": "^1.0.30001706",
     "cloudinary-build-url": "^0.2.4",

--- a/src/components/content/projects/ProjectCard.tsx
+++ b/src/components/content/projects/ProjectCard.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
-import Image from 'next/image';
 import * as React from 'react';
 
+import NextImage from '@/components/images/NextImage';
 import UnstyledLink from '@/components/links/UnstyledLink';
 import TechIcons, { TechListType } from '@/components/TechIcons';
 
@@ -38,15 +38,10 @@ export default function ProjectCard({ project, className }: ProjectCardProps) {
 
         {/* 使用 next/image 组件加载图片 */}
         <div className='pointer-events-none relative mt-3 w-full'>
-          <Image
+          <NextImage
             src={project.banner}
             alt={project.title}
-            layout='responsive'
-            width={1440}
-            height={792}
             objectFit='cover'
-            placeholder='blur' // 可选：添加模糊占位符
-            blurDataURL='/path/to/blur-placeholder.jpg' // 可选：模糊占位符图片路径
           />
         </div>
 

--- a/src/components/images/NextImage.tsx
+++ b/src/components/images/NextImage.tsx
@@ -2,13 +2,16 @@ import clsx from 'clsx';
 import Image, { ImageProps } from 'next/image';
 import * as React from 'react';
 
+type ImgElementStyle = NonNullable<JSX.IntrinsicElements['img']['style']>;
+
 type NextImageProps = {
   useSkeleton?: boolean;
   imgClassName?: string;
   blurClassName?: string;
   alt: string;
-  width: string | number;
-  height: string | number;
+  width?: string | number;
+  height?: string | number;
+  objectFit?: ImgElementStyle['objectFit'];
 } & ImageProps;
 
 /**
@@ -25,6 +28,7 @@ export default function NextImage({
   className,
   imgClassName,
   blurClassName,
+  objectFit,
   ...rest
 }: NextImageProps) {
   const [status, setStatus] = React.useState(
@@ -40,13 +44,17 @@ export default function NextImage({
       <Image
         className={clsx(
           imgClassName,
+          blurClassName,
           // text-gray to hide alt text
-          'bg-gray-400 text-gray-400 ',
-          status === 'loading' && clsx('animate-pulse', blurClassName)
+          //'bg-gray-400 text-gray-400 ',
+          status === 'loading' &&
+            clsx('animate-pulse', 'bg-gray-400 text-gray-400 ')
         )}
         src={src}
-        width={width}
-        height={height}
+        width={width || '1440'}
+        height={height || '720'}
+        // width，height uncertain，use objectFit
+        objectFit={objectFit}
         alt={alt}
         onLoadingComplete={() => setStatus('complete')}
         {...rest}

--- a/src/contents/projects/bjut-chaoxing.mdx
+++ b/src/contents/projects/bjut-chaoxing.mdx
@@ -107,7 +107,7 @@ link: 'https://github.com/bjut-swift/chaoxing-bjut'
 
 ### 贡献
 
-- <Image
+- <NextImage
     src='https://vuejs.org/logo-uwu.png'
     alt='Vue.js'
     width={227}

--- a/src/contents/projects/bjut-latex.mdx
+++ b/src/contents/projects/bjut-latex.mdx
@@ -35,7 +35,7 @@ Overleaf 版本已经通过审核并上线，同学们可以通过 Overleaf 开�
 
 # 预览
 
-<Image
+<NextImage
   src='https://cdn.bjutswift.cn/https://github.com/bjut-swift/swift-image-hosting/blob/main/swift-nest/post/latex.png'
   alt='右侧示例图片'
   width={600}

--- a/src/contents/projects/bjut-ppt-temple.mdx
+++ b/src/contents/projects/bjut-ppt-temple.mdx
@@ -25,7 +25,7 @@ link: 'https://github.com/bjut-swift/BJUT-PPT-template'
 
 也可以直接双击直接**新建**基于模版的幻灯片。
 
-<Image
+<NextImage
   src='https://cdn.bjutswift.cn/https://github.com/bjut-swift/BJUT-PPT-template/blob/master/Support/switch.png'
   alt='右侧示例图片'
   width={800}
@@ -37,7 +37,7 @@ link: 'https://github.com/bjut-swift/BJUT-PPT-template'
 
 ## 16:9 模板预览 🐬
 
-<Image
+<NextImage
   src='https://cdn.bjutswift.cn/https://raw.githubusercontent.com/bjut-swift/BJUT-PPT-template/master/Support/16-9.png'
   alt='右侧示例图片'
   width={800}
@@ -46,7 +46,7 @@ link: 'https://github.com/bjut-swift/BJUT-PPT-template'
   className='my-4 w-full rounded-lg shadow-lg'
 />
 ## 4:3 模板预览 🐬
-<Image
+<NextImage
   src='https://cdn.bjutswift.cn/https://raw.githubusercontent.com/bjut-swift/BJUT-PPT-template/master/Support/4-3.png'
   alt='右侧示例图片'
   width={800}


### PR DESCRIPTION
# What does this PR do?
## 回退@waline/client版本
关于版本为什么改变

最开始bun install --save-text-lockfile --frozen-lockfile --lockfile-only
这个命令是把lockb换成lock，但是不更新原lockb的内容（假设原先lockb是4月3日的依赖

然后depbot 执行bun install 更新依赖（拉的是4月10号的依赖）报错了，原因是lock文件3号和10号的依赖信息对不上

所以我在本地bun install了一次，把lock文件从3号更新到10号，以解决depbot报错，对应 update lock commit


于是depbot不报错了，但是代价是锁文件从3号更新到10号，3号的waline最新版在3.1.x，10号的最新版是3.5.x，变得太新了所以寄了

省流：中间为了解决depbot报错更新了一次lock文件


## Image组件添加占位图

维持原skeleton逻辑，修复skeleton没跟loading关联

## skeleton冲突

从Image暴露objectfit props给NextImage,继续使用封装好的NextImage

## Before submitting

- [x] Have you deployed and tested locally?
- [ ] Have you checked Chinese/English typography standards?
