### PR TITLE
fix: 优化博客封面图的 alt 文本

### DIFF
--- a/src/components/content/blog/BlogCard.tsx
+++ b/src/components/content/blog/BlogCard.tsx
@@ -45,7 +45,7 @@ export default function BlogCard({
             >
               <Image
                 src={post.banner}
-                alt={`Photo from external link: ${post.banner}`}
+                alt={`${post.title} 封面图`}
                 fill
                 sizes='100vw'
                 style={{


### PR DESCRIPTION
# 修改内容

解决 Issue #102 将 `BlogCard` 组件中博客封面图的 `alt` 文本由外部 CDN 链接描述改为基于文章标题的描述，使其对无障碍访问更有意义。