### PR TITLE
test: update render Cypress spec for current route

### DIFF
--- a/cypress/e2e/pages/render.spec.ts
+++ b/cypress/e2e/pages/render.spec.ts
@@ -9,41 +9,37 @@ describe('All Page', () => {
 
   it('should display index page', () => {
     cy.visit('/');
-    cy.get('h1').should('contain', 'BJUT SWIFT');
-  });
-
-  it('should display about page', () => {
-    cy.visit('/about');
-    cy.get('h1').should('contain', 'BJUT SWIFT');
+    cy.get('h1').should('contain', 'BJUT').and('contain', 'SWIFT');
+    cy.contains('a', '留言簿').should('be.visible');
   });
 
   it('should display blog page', () => {
     cy.visit('/blog');
-    cy.get('h1').should('contain', 'Blog');
+    cy.contains('h1', '专栏分享').should('be.visible');
+    cy.get('input[placeholder="搜索..."]').should('be.visible');
   });
 
-  it('should display library page', () => {
-    cy.visit('/library');
-    cy.get('h1').should('contain', 'Library');
+  it('should display feiyue page', () => {
+    cy.visit('/feiyue');
+    cy.contains('h1', '北京工业大学飞跃手册').should('be.visible');
+    cy.get('input[placeholder="搜索申请人、专业、方向..."]').should('be.visible');
   });
 
   it('should display projects page', () => {
     cy.visit('/projects');
-    cy.get('h1').should('contain', 'Projects');
+    cy.contains('h1', '已有项目').should('be.visible');
+    cy.contains('p', '正在发展中，欢迎任何同学参与建设。').should('be.visible');
   });
 
-  it('should display subscribe page', () => {
-    cy.visit('/subscribe');
-    cy.get('h1').should('contain', 'Subscribe to BJUT SWIFT');
+  it('should display shorts page', () => {
+    cy.visit('/shorts');
+    cy.contains('h1', '教程').should('be.visible');
+    cy.get('input[placeholder="Search..."]').should('be.visible');
   });
 
-  it('should display trf bca page', () => {
-    cy.visit('/trf/bca');
-    cy.get('h1').should('contain', 'Rekening BCA');
-  });
-
-  it('should display trf mandiri page', () => {
-    cy.visit('/trf/mandiri');
-    cy.get('h1').should('contain', 'Rekening Mandiri');
+  it('should display guestbook page', () => {
+    cy.visit('/guestbook');
+    cy.contains('h1', '留言簿').should('be.visible');
+    cy.contains('a', 'GitHub Discussions').should('be.visible');
   });
 });

--- a/cypress/e2e/pages/render.spec.ts
+++ b/cypress/e2e/pages/render.spec.ts
@@ -13,6 +13,16 @@ describe('All Page', () => {
     cy.contains('a', '留言簿').should('be.visible');
   });
 
+  it('should display about page', () => {
+    cy.visit('/about');
+    cy.get('h1').should('contain', 'BJUT').and('contain', 'SWIFT');
+  });
+
+  it('should display subscribe page', () => {
+    cy.visit('/subscribe');
+    cy.contains('h1', '订阅').should('be.visible');
+  });
+
   it('should display blog page', () => {
     cy.visit('/blog');
     cy.contains('h1', '专栏分享').should('be.visible');


### PR DESCRIPTION
# What does this PR do?

Fixes #115

## Summary

Updated the Cypress render spec to cover the current site routes.

## Changes

* Replaced stale route checks for removed or renamed pages.
* Added assertions for `/`, `/feiyue`, `/blog`, `/projects`, `/shorts`, and `/guestbook`.

## Tests

* `git diff --check origin/main..HEAD`

Cypress was not run locally because the current checkout does not include the required `bun` environment or installed dependencies. The change is limited to route assertion updates in the existing render spec.

## Notes

* No user-facing copy was changed; Chinese text is only used in Cypress assertions against existing page content.
