### PR TITLE
ci: auto-thank external contributors after merge

### DIFF
--- a/.github/workflows/thank-contributor.yml
+++ b/.github/workflows/thank-contributor.yml
@@ -1,0 +1,32 @@
+name: Thank external contributor
+
+on:
+  pull_request_target:
+    types: [closed]
+
+jobs:
+  thank:
+    # 仅当「来自 fork 的外部贡献者」PR 被合并时触发；
+    # 跳过组织内分支（dependabot、自己推的分支等）和机器人。
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.fork == true &&
+      github.event.pull_request.user.type != 'Bot'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment on merged PR
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: [
+                '感谢贡献，已合并 🎉',
+                '',
+                '小建议：如果想让这次贡献在你的 GitHub 主页上更显眼，可以到 profile 页面点 "Customize your pins"，把这个仓库 pin 到顶部——比默认显示 fork 更有 impact，也算是对组织的一份支持～',
+              ].join('\n'),
+            });


### PR DESCRIPTION
合并来自 fork 的外部贡献者 PR 时,自动回复一条「感谢 + 建议把仓库 pin 到主页」的评论,替代之前的手动操作。

## 设计
- `pull_request_target` + `types: [closed]` + `merged == true` —— 只在合并时触发,且 fork PR 也能拿到发评论的写权限
- `head.repo.fork == true && user.type != 'Bot'` —— 仅外部 fork 贡献者,自动排除 dependabot、组织内分支、机器人
- `permissions: pull-requests: write` —— 最小权限
- 仅读事件元数据 + 发评论,不 checkout/执行 fork 代码,无注入风险

🤖 Generated with [Claude Code](https://claude.com/claude-code)