### PR TITLE
ci: only auto-thank first-time contributors

### DIFF
--- a/.github/workflows/thank-contributor.yml
+++ b/.github/workflows/thank-contributor.yml
@@ -6,10 +6,12 @@ on:
 
 jobs:
   thank:
-    # 仅当「来自 fork 的外部贡献者」PR 被合并时触发；
+    # 仅当「首次贡献者」来自 fork 的 PR 被合并时触发；
+    # FIRST_TIME_CONTRIBUTOR 保证只在某人对本仓库的第一个 PR 发；
     # 跳过组织内分支（dependabot、自己推的分支等）和机器人。
     if: >-
       github.event.pull_request.merged == true &&
+      github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR' &&
       github.event.pull_request.head.repo.fork == true &&
       github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest


### PR DESCRIPTION
给 auto-thank workflow 加 `author_association == 'FIRST_TIME_CONTRIBUTOR'` 条件:感谢 + pin 建议只在某人对本仓库的**首个** PR 合并时发出。

- 回头客(如重复提交飞跃记录者)不再被自动感谢
- "pin 到主页"这类话本就只对新人首次贡献合适
- 仍保留 fork + 非机器人 的过滤

🤖 Generated with [Claude Code](https://claude.com/claude-code)